### PR TITLE
Allow displaying an SVG logo using svg source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+
+.idea/

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {ImageSourcePropType} from "react-native";
+import type {ImageSourcePropType} from "react-native";
 import type {SvgProps} from "react-native-svg";
 
 declare class QRCode extends React.PureComponent<QRCodeProps, any> {}
@@ -18,7 +18,7 @@ export interface QRCodeProps {
   * In case both this prop and `logo` are provided, then this prop takes precedence and `logo` will be ignored. */
   logoSVG?: React.FC<SvgProps> | string;
   /* an image source object. example {uri: 'base64string'} or {require('pathToImage')} */
-  logo?: ImageSourcePropType;
+  logo?: ImageSourcePropType | string;
   /* logo size in pixels */
   logoSize?: number;
   /* the logo gets a filled rectangular background with this color. Use 'transparent'

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ export interface QRCodeProps {
   backgroundColor?: string;
   /* SVG to render as logo.
   * Can be either a svg string or a React component if you're using ex: '@svgr/webpack' or similar
-  * In case both this prop `logo` is provided, then this takes precedence and `logo` will be ignored. */
+  * In case both this prop and `logo` are provided, then this prop takes precedence and `logo` will be ignored. */
   logoSVG?: React.FC<SvgProps> | string;
   /* an image source object. example {uri: 'base64string'} or {require('pathToImage')} */
   logo?: ImageSourcePropType;
@@ -24,8 +24,8 @@ export interface QRCodeProps {
   /* the logo gets a filled rectangular background with this color. Use 'transparent'
          if your logo already has its own backdrop. Default = same as backgroundColor */
   logoBackgroundColor?: string;
-  /* If the logo is provided via SVG this color will be set as it's `fill` property
-  * it does nothing if logo is provided as an Image source object */
+  /* If the logo is provided via `logoSVG` prop, this color will be set as it's `fill` property,
+  * otherwise it does nothing */
   logoColor?: string;
   /* logo's distance to its wrapper */
   logoMargin?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,8 +14,9 @@ export interface QRCodeProps {
   /* the color of the background */
   backgroundColor?: string;
   /* SVG to render as logo.
-  * If this prop is provided then `logo` prop will be ignored. */
-  logoSVG?: React.FC<SvgProps>;
+  * Can be either a svg string or a React component if you're using ex: '@svgr/webpack' or similar
+  * In case both this prop `logo` is provided, then this takes precedence and `logo` will be ignored. */
+  logoSVG?: React.FC<SvgProps> | string;
   /* an image source object. example {uri: 'base64string'} or {require('pathToImage')} */
   logo?: ImageSourcePropType;
   /* logo size in pixels */

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
-import { Image, ImageSourcePropType } from "react-native";
+import {ImageSourcePropType} from "react-native";
+import type {SvgProps} from "react-native-svg";
 
 declare class QRCode extends React.PureComponent<QRCodeProps, any> {}
 
@@ -12,6 +13,9 @@ export interface QRCodeProps {
   color?: string;
   /* the color of the background */
   backgroundColor?: string;
+  /* SVG to render as logo.
+  * If this prop is provided then `logo` prop will be ignored. */
+  logoSVG?: React.FC<SvgProps>;
   /* an image source object. example {uri: 'base64string'} or {require('pathToImage')} */
   logo?: ImageSourcePropType;
   /* logo size in pixels */
@@ -19,6 +23,9 @@ export interface QRCodeProps {
   /* the logo gets a filled rectangular background with this color. Use 'transparent'
          if your logo already has its own backdrop. Default = same as backgroundColor */
   logoBackgroundColor?: string;
+  /* If the logo is provided via SVG this color will be set as it's `fill` property
+  * it does nothing if logo is provided as an Image source object */
+  logoColor?: string;
   /* logo's distance to its wrapper */
   logoMargin?: number;
   /* the border-radius of logo image */

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
   },
   "homepage": "https://github.com/awesomejerry/react-native-qrcode-svg#readme",
   "peerDependencies": {
-    "react-native": ">=0.63.4",
     "react": "*",
+    "react-native": ">=0.63.4",
     "react-native-svg": ">=13.2.0"
   },
   "dependencies": {
@@ -51,6 +51,7 @@
     "qrcode": "^1.5.1"
   },
   "devDependencies": {
+    "@types/react": "^18.2.75",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^27.4.2",
     "husky": "^7.0.4",

--- a/src/LogoSVG/index.js
+++ b/src/LogoSVG/index.js
@@ -1,0 +1,10 @@
+import React from 'react'
+
+const LogoSVG = ({ svg, logoSize, logoColor }) => {
+    // the svg prop is actually a svg wrapped in a React component, so for the web we can just render it
+    const LogoSVGComponent = svg;
+
+    return <LogoSVGComponent fill={logoColor} width={logoSize} height={logoSize} />;
+}
+
+export default LogoSVG;

--- a/src/LogoSVG/index.js
+++ b/src/LogoSVG/index.js
@@ -13,7 +13,7 @@ const LogoSVG = ({ svg, logoSize, logoColor }) => {
         />
     }
 
-    // if svg prop is actually a svg wrapped in a React component, then we can just render it
+    // if `svg` prop is actually a svg asset wrapped in a React component, then we can just render it
     const LogoSVGComponent = svg;
 
     return <LogoSVGComponent fill={logoColor} width={logoSize} height={logoSize} />;

--- a/src/LogoSVG/index.js
+++ b/src/LogoSVG/index.js
@@ -1,7 +1,19 @@
 import React from 'react'
+import {Image} from "react-native-svg";
+import {isString, isUrlString} from "../utils";
 
 const LogoSVG = ({ svg, logoSize, logoColor }) => {
-    // the svg prop is actually a svg wrapped in a React component, so for the web we can just render it
+    if(isString(svg)) {
+        const href = isUrlString(svg) ? svg : `data:image/svg+xml;base64,${window.btoa(svg)}`;
+
+        return <Image
+            href={encodeURI(href)}
+            width={logoSize}
+            height={logoSize}
+        />
+    }
+
+    // if svg prop is actually a svg wrapped in a React component, then we can just render it
     const LogoSVGComponent = svg;
 
     return <LogoSVGComponent fill={logoColor} width={logoSize} height={logoSize} />;

--- a/src/LogoSVG/index.native.js
+++ b/src/LogoSVG/index.native.js
@@ -1,7 +1,17 @@
 import React from 'react'
 import {LocalSvg} from 'react-native-svg/css'
+import {SvgUri, SvgXml} from "react-native-svg";
+import {isString, isUrlString} from "../utils";
 
 const LogoSVG = ({ svg, logoSize, logoColor }) => {
+    if (isString(svg)) {
+        if (isUrlString(svg)) {
+            return <SvgUri uri={svg} fill={logoColor} width={logoSize} height={logoSize} />
+        }
+
+        return <SvgXml xml={svg} fill={logoColor} width={logoSize} height={logoSize} />;
+    }
+
     return <LocalSvg asset={svg} fill={logoColor} width={logoSize} height={logoSize} />;
 }
 

--- a/src/LogoSVG/index.native.js
+++ b/src/LogoSVG/index.native.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import {LocalSvg} from 'react-native-svg/css'
+
+const LogoSVG = ({ svg, logoSize, logoColor }) => {
+    return <LocalSvg asset={svg} fill={logoColor} width={logoSize} height={logoSize} />;
+}
+
+export default LogoSVG;

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import LogoSVG from './LogoSVG'
 
 const renderLogo = ({
   size,
+  backgroundColor,
   logo,
   logoSVG,
   logoSize,
@@ -23,7 +24,6 @@ const renderLogo = ({
   logoMargin,
   logoBorderRadius,
 }) => {
-
   const logoPosition = (size - logoSize - logoMargin * 2) / 2
   const logoBackgroundSize = logoSize + logoMargin * 2
   const logoBackgroundBorderRadius =
@@ -53,15 +53,18 @@ const renderLogo = ({
         <Rect
           width={logoBackgroundSize}
           height={logoBackgroundSize}
-          fill={logoBackgroundColor}
+          fill={backgroundColor}
           clipPath='url(#clip-logo-background)'
         />
       </G>
-      <G x={logoMargin} y={logoMargin}>
+      <G x={logoMargin} y={logoMargin} clipPath='url(#clip-logo)'>
+        <Rect
+            width={logoBackgroundSize - logoMargin}
+            height={logoBackgroundSize - logoMargin}
+            fill={logoBackgroundColor}
+        />
         {logoSVG ? (
-          <G clipPath='url(#clip-logo)'>
             <LogoSVG svg={logoSVG} logoSize={logoSize} logoColor={logoColor} />
-          </G>
         ) : (
             <Image
               width={logoSize}
@@ -85,7 +88,7 @@ const QRCode = ({
   logoSVG,
   logoSize = size * 0.2,
   logoBackgroundColor = 'transparent',
-  logoColor = "#000000",
+  logoColor,
   logoMargin = 2,
   logoBorderRadius = 0,
   quietZone = 0,
@@ -160,6 +163,7 @@ const QRCode = ({
       {displayLogo &&
         renderLogo({
           size,
+          backgroundColor,
           logo,
           logoSVG,
           logoSize,

--- a/src/index.js
+++ b/src/index.js
@@ -11,15 +11,19 @@ import Svg, {
 } from 'react-native-svg'
 import genMatrix from './genMatrix'
 import transformMatrixIntoPath from './transformMatrixIntoPath'
+import LogoSVG from './LogoSVG'
 
 const renderLogo = ({
   size,
   logo,
+  logoSVG,
   logoSize,
   logoBackgroundColor,
+  logoColor,
   logoMargin,
-  logoBorderRadius
+  logoBorderRadius,
 }) => {
+
   const logoPosition = (size - logoSize - logoMargin * 2) / 2
   const logoBackgroundSize = logoSize + logoMargin * 2
   const logoBackgroundBorderRadius =
@@ -54,13 +58,19 @@ const renderLogo = ({
         />
       </G>
       <G x={logoMargin} y={logoMargin}>
-        <Image
-          width={logoSize}
-          height={logoSize}
-          preserveAspectRatio='xMidYMid slice'
-          href={logo}
-          clipPath='url(#clip-logo)'
+        {logoSVG ? (
+          <G clipPath='url(#clip-logo)'>
+            <LogoSVG svg={logoSVG} logoSize={logoSize} logoColor={logoColor} />
+          </G>
+        ) : (
+            <Image
+              width={logoSize}
+              height={logoSize}
+              preserveAspectRatio='xMidYMid slice'
+              href={logo}
+              clipPath='url(#clip-logo)'
         />
+        )}
       </G>
     </G>
   )
@@ -72,8 +82,10 @@ const QRCode = ({
   color = 'black',
   backgroundColor = 'white',
   logo,
+  logoSVG,
   logoSize = size * 0.2,
   logoBackgroundColor = 'transparent',
+  logoColor = "#000000",
   logoMargin = 2,
   logoBorderRadius = 0,
   quietZone = 0,
@@ -101,7 +113,8 @@ const QRCode = ({
     return null
   }
 
-  const { path, cellSize } = result
+  const { path, cellSize } = result;
+  const displayLogo = logo || logoSVG;
 
   return (
     <Svg
@@ -144,14 +157,16 @@ const QRCode = ({
           strokeWidth={cellSize}
         />
       </G>
-      {logo &&
+      {displayLogo &&
         renderLogo({
           size,
           logo,
+          logoSVG,
           logoSize,
           logoBackgroundColor,
+          logoColor,
           logoMargin,
-          logoBorderRadius
+          logoBorderRadius,
         })}
     </Svg>
   )

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,7 @@
+export function isString(variable) {
+    return typeof variable === "string";
+}
+
+export function isUrlString(variable) {
+    return isString(variable) && variable.startsWith("http");
+}


### PR DESCRIPTION
## Problem
in the current version of this library only image assets (like `.png` etc) can be used as a logo within QR code, svg assets would not work.

## What this does
This PR tries to make it possible to use svgs.

I have not found any reasonable way to do this via the single `logo` prop, as there is no React component that could accept either `ImageSourcePropType` or an SVG and handle every case correctly. Some conditional logic is required to handle the svg prop, thats why I decided to add it as a new prop, while the old `logo` prop will work unchanged.

 - add (optional) `logoSVG` prop that accepts an svg and will render it
 - add (optional) `logoColor` prop to set the `fill` property of the logo
 - this solution handles: 
   - a string svg, ex: `"<svg ....>"`
   - an URL pointing to an svg image, ex: https://raw.githubusercontent.com/software-mansion/react-native-svg/4b51a41a22432030a3396e847dc7d5aec5a86ae9/TestsExample/assets/ruby.svg
   - a svg React component (this is something that Expensify project uses via `@svgr/webpack` - its a very popular lib)
 - on web we either render the svg logo if its a component OR in case of string we use standard `Image` from `react-native-svg`
 - on native ios/android we use special dedicated components from `react-native-svg` which handle all the cases

**I consider this WIP and api might still change**


## examples
### ios
<img width="247" alt="Screenshot 2024-03-27 at 14 40 35" src="https://github.com/Kicu/react-native-qrcode-svg/assets/3929868/d63caf28-dbf3-4b6e-b527-ee7b04fcf01b">

### web
<div>
<img width="248" alt="Screenshot 2024-04-03 at 10 25 06" src="https://github.com/Kicu/react-native-qrcode-svg/assets/3929868/d2ca721f-43e1-41d9-941f-da56c0a5c673">
<img width="255" alt="Screenshot 2024-04-03 at 10 36 52" src="https://github.com/Kicu/react-native-qrcode-svg/assets/3929868/0f25c024-4de0-4472-a508-e3ed331f2929">
</div>

### android
<img width="205" alt="Screenshot 2024-04-03 at 10 37 44" src="https://github.com/Kicu/react-native-qrcode-svg/assets/3929868/2a9c4efa-7ecf-43ef-8bc1-99a1349212fd">



